### PR TITLE
fix justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ project_dir   := justfile_directory()
 project_name  := file_stem(justfile_directory())
 
 typst_version := "typst -V"
-typst_github  := "https://github.com/typst/typst --tag v0.11.0"
+typst_github  := "https://github.com/typst/typst typst-cli --tag v0.11.0"
 
 output_dir    := "05-pdf"
 doc_name      := "main"


### PR DESCRIPTION
To install Typst, it is required to put the `typst-cli` argument as indicated in the installation instructions on the Typst repository